### PR TITLE
Update to fix deprecations for 2.076.

### DIFF
--- a/examples/02.Interfacing/source/app.d
+++ b/examples/02.Interfacing/source/app.d
@@ -9,7 +9,8 @@
 */
 module example02;
 
-import std.datetime;
+static if( __VERSION__ < 2075) import std.datetime;
+else import core.time;
 
 import dlogg.strict;
 import daemonize.d;
@@ -47,12 +48,21 @@ version(DaemonServer)
                 return true;
             }
         ),
-        
-        (logger, shouldExit) 
+
+        (logger, shouldExit)
         {
             // will stop the daemon in 5 minutes
-            auto time = Clock.currSystemTick + cast(TickDuration)5.dur!"minutes";
-            while(!shouldExit() && time > Clock.currSystemTick) {  }
+            static if( __VERSION__ < 2075 )
+            {
+                auto time = Clock.currSystemTick + cast(TickDuration)5.dur!"minutes";
+                alias currTime = Clock.currSystemTick;
+            }
+            else
+            {
+                auto time = MonoTime.currTime + 5.dur!"minutes";
+                alias currTime = MonoTime.currTime;
+            }
+            while(!shouldExit() && time > currTime) {  }
             logger.logInfo("Exiting main function!");
             
             return 0;

--- a/source/daemonize/linux.d
+++ b/source/daemonize/linux.d
@@ -14,7 +14,17 @@ module daemonize.linux;
 
 version(linux):
 
-static if( __VERSION__ < 2066 ) private enum nogc;
+static if( __VERSION__ < 2070 )
+{
+    import std.c.stdlib;
+    import std.c.linux.linux;
+}
+else
+{
+    import core.stdc.stdlib;
+    import core.sys.posix.unistd;
+    import core.sys.posix.signal;
+}
 
 import std.conv;
 import std.exception;
@@ -24,10 +34,8 @@ import std.process;
 import std.stdio;
 import std.string;
 
-import std.c.linux.linux;
-import std.c.stdlib;
 import core.sys.linux.errno;
-    
+
 import daemonize.daemon;
 import daemonize.string;
 import daemonize.keymap;


### PR DESCRIPTION
On Linux, it wouldn't build on pre-2.069 compilers (calls to `_d_critical_term` and `_d_monitor_staticdtor` on lines 528, 529) so I removed the pre-2.066 check. I haven't tested on anything but 2.076 for Windows.

In windows.d on line 534, it casts Duration to Duration on recent compilers; the line could be moved to a `static if` but my theory is that it won't hurt anything.