### PR TITLE
Fix issue 7: Make Dlogg an optional dependency.

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -8,13 +8,13 @@
         {
             "name": "default",
             "dependencies" : {
-                "dlogg": ">=0.3.3" 
+                "dlogg": { "version": "~>0.4.1" , "optional": true }
             }
         },
         {
             "name": "colorized",
             "dependencies" : {
-                "dlogg": ">=0.3.3"
+                "dlogg": { "version": "~>0.4.1" , "optional": true }
             },
             "subConfigurations" : {
                 "dlogg": "colorized"

--- a/examples/01.HelloWorld/README.md
+++ b/examples/01.HelloWorld/README.md
@@ -6,11 +6,9 @@ The example demonstrates simple daemon that prints `"Hello World!"` to log when 
 Explanation
 ===========
 
-The first thing you should do is to import `daemonize.d` package that exporting all inner modules
-taking in account current OS. Also daemonize package depends on `dlogg` package for easy handling
-of concurrent and lazy logging:
+The first thing you should do is to import `daemonize.d` package that exports all inner modules
+taking in account current OS:
 ```D
-import dlogg.strict;
 import daemonize.d;
 ```
 
@@ -59,13 +57,13 @@ Main function of the daemon goes further:
         auto time = Clock.currSystemTick + cast(TickDuration)5.dur!"minutes";
         bool timeout = false;
         while(!shouldExit() && time > Clock.currSystemTick) {  }
-        
+
         logger.logInfo("Exiting main function!");
-        
+
         return 0;
     }
 ```
-`shouldExit` should be `int function(shared ILogger, bool function())` type and is used to stop main function from
+`shouldExit` should be `int function(shared IDaemonLogger, bool function())` type and is used to stop main function from
 signal callbacks. As soon as main delegate returns, the daemon terminates. At the example the daemon will auto-stop after 5 minutes.
 
 
@@ -76,8 +74,8 @@ int main()
     // For windows is important to use absolute path for logging
     version(Windows) string logFilePath = "C:\\logfile.log";
     else string logFilePath = "logfile.log";
-    
-    auto logger = new shared StrictLogger(logFilePath);
+
+    auto logger = new shared DloggLogger(logFilePath);
 ```
 
 And then:

--- a/examples/02.Interfacing/README.md
+++ b/examples/02.Interfacing/README.md
@@ -80,13 +80,13 @@ Daemon description is similar to [Example 01](https://github.com/NCrashed/daemon
         // For windows is important to use absolute path for logging
         version(Windows) string logFilePath = "C:\\logfile.log";
         else string logFilePath = "logfile.log";
-        
-        auto logger = new shared StrictLogger(logFilePath);
-        return buildDaemon!daemon.run(logger); 
+
+        auto logger = new shared DloggLogger(logFilePath);
+        return buildDaemon!daemon.run(logger);
     }
 ```
 
-As custom signals are mapped to native ones at runtime, guessing actuall signal id is a quite
+As custom signals are mapped to native ones at runtime, guessing the actual signal id is a quite
 complicated task (Windows version binds to string names, that is much more repitable). `daemonize`
 provides utilities to control created daemons from D code.
 

--- a/examples/02.Interfacing/dub.json
+++ b/examples/02.Interfacing/dub.json
@@ -5,7 +5,8 @@
 	"license": "MIT",
 	"authors": ["Anton Gushcha (NCrashed) <ncrashed@gmail.com>"],
 	"dependencies" : {
-		"daemonize": {"version": "~master", "path": "../.."}  
+		"daemonize": {"version": "~master", "path": "../.."},
+		"dlogg": "~>0.4.1"
 	},
 	"subConfigurations": {
 		"daemonize": "colorized"
@@ -22,6 +23,6 @@
 			"targetType": "executable",
 			"targetName": "ex2-client",
 			"versions": ["DaemonClient"]
-		}	
+		}
 	]
 }

--- a/examples/02.Interfacing/source/app.d
+++ b/examples/02.Interfacing/source/app.d
@@ -11,7 +11,6 @@ module example02;
 
 import std.datetime;
 
-import dlogg.strict;
 import daemonize.d;
 
 // Describing custom signals
@@ -64,9 +63,9 @@ version(DaemonServer)
         // For windows is important to use absolute path for logging
         version(Windows) string logFilePath = "C:\\logfile.log";
         else string logFilePath = "logfile.log";
-		
-        auto logger = new shared StrictLogger(logFilePath);
-        return buildDaemon!daemon.run(logger); 
+
+        auto logger = new shared DloggLogger(logFilePath);
+        return buildDaemon!daemon.run(logger);
     }
 }
 version(DaemonClient)
@@ -87,8 +86,8 @@ version(DaemonClient)
     
     void main()
     {
-    	auto logger = new shared StrictLogger("client.log");
-    	
+    	auto logger = new shared DloggLogger("client.log");
+
     	alias daemon = buildDaemon!client;
     	alias send = daemon.sendSignal;
     	alias uninstall = daemon.uninstall;

--- a/examples/03.Vibed/README.md
+++ b/examples/03.Vibed/README.md
@@ -7,14 +7,13 @@ to `localhost:8080` and responds with simple hello-world page.
 Explanation
 ===========
 
-The vibe and dlogg package use same names for logging utilities, thats why we need some qualified imports:
 ```D
 import dlogg.strict;
 import daemonize.d;
 
-// cannot use vibe.d due symbol clash for logging
 import vibe.core.core;
-import vibe.core.log : setLogLevel, setLogFile, VibeLogLevel = LogLevel;
+import vibe.core.log;
+import vibe.core.log : VibeLogLevel = LogLevel;
 import vibe.http.server;
 ```
 
@@ -84,8 +83,8 @@ int main()
 
     version(Windows) enum logFileName = "C:\\logfile.log";
     else enum logFileName = "logfile.log";
-    
-    auto logger = new shared StrictLogger(logFileName);
-    return buildDaemon!daemon.run(logger); 
+
+    auto logger = new shared DloggLogger(logFileName);
+    return buildDaemon!daemon.run(logger);
 }
 ```

--- a/examples/03.Vibed/dub.json
+++ b/examples/03.Vibed/dub.json
@@ -7,6 +7,7 @@
 	"versions": ["VibeCustomMain"],
 	"dependencies" : {
 		"daemonize": {"version": "~master", "path": "../.."},
+		"dlogg": "~>0.4.1",
 		"vibe-d": "~master"
 	},
 	"subConfigurations": {

--- a/examples/03.Vibed/source/app.d
+++ b/examples/03.Vibed/source/app.d
@@ -12,12 +12,11 @@
 */
 module example03;
 
-import dlogg.strict;
 import daemonize.d;
 
-// cannot use vibe.d due symbol clash for logging
 import vibe.core.core;
-import vibe.core.log : setLogLevel, setLogFile, VibeLogLevel = LogLevel;
+import vibe.core.log;
+import vibe.core.log : VibeLogLevel = LogLevel;
 import vibe.http.server;
 
 // Simple daemon description
@@ -77,7 +76,7 @@ int main()
 
     version(Windows) enum logFileName = "C:\\logfile.log";
     else enum logFileName = "logfile.log";
-	
-    auto logger = new shared StrictLogger(logFileName);
-    return buildDaemon!daemon.run(logger); 
+
+    auto logger = new shared DloggLogger(logFileName);
+    return buildDaemon!daemon.run(logger);
 }

--- a/examples/04.CustomLogger/README.md
+++ b/examples/04.CustomLogger/README.md
@@ -1,27 +1,48 @@
-﻿// This file is written in D programming language
-/**
-*   The example demonstrates basic daemonize features. Described
-*   daemon responds to SIGTERM and SIGHUP signals.
-*   
-*   If SIGTERM is received, daemon terminates. If SIGHUP is received,
-*   daemon prints "Hello World!" message to logg.
-*
-*   Daemon will auto-terminate after 5 minutes of running.
-*
-*   Copyright: © 2014 Anton Gushcha
-*   License: Subject to the terms of the MIT license, as written in the included LICENSE file.
-*   Authors: NCrashed <ncrashed@gmail.com>
-*/
-module example01;
+Example 04 Custom Logger
+========================
 
-import std.datetime;
+This small example shows how to pass your custom logging library to daemonize.
 
-import daemonize.d;
+Explanation
+===========
 
-// First you need to describe your daemon via template
+Create a synchronized class that implements the IDaemonLogger interface and wraps your logging library.
+
+```
+synchronized class MyLogger : IDaemonLogger
+{
+    private string file;
+
+    this(string filePath) @trusted
+    {
+        file = filePath;
+    }
+
+    void logDebug(string message) nothrow
+    {
+        debug {
+            import std.stdio : toFile;
+            try message.toFile(file);
+            catch (Exception) {}
+        }
+    }
+
+    void logInfo(lazy string message) nothrow
+    {
+        import std.stdio : toFile;
+        try message.toFile(file);
+        catch (Exception) {}
+    }
+    /* ... */
+}
+```
+
+Create your daemon template, then in your `main` function pass your logging class to daemonize:
+
+```
 alias daemon = Daemon!(
-    "DaemonizeExample1", // unique name
-    
+    "DaemonizeExample4", // unique name
+
     // Setting associative map signal -> callbacks
     KeyValueList!(
         // You can bind same delegate for several signals by Composition template
@@ -37,15 +58,15 @@ alias daemon = Daemon!(
             return true; // continue execution
         }
     ),
-    
+
     // Main function where your code is
     (logger, shouldExit) {
         // will stop the daemon in 5 minutes
         auto time = Clock.currSystemTick + cast(TickDuration)5.dur!"minutes";
         while(!shouldExit() && time > Clock.currSystemTick) {  }
-        
+
         logger.logInfo("Exiting main function!");
-        
+
         return 0;
     }
 );
@@ -56,5 +77,7 @@ int main()
     version(Windows) string logFilePath = "C:\\logfile.log";
     else string logFilePath = "logfile.log";
 
-    return buildDaemon!daemon.run(new shared DloggLogger(logFilePath));
+    return buildDaemon!daemon.run(new shared MyLogger(logFilePath));
 }
+```
+

--- a/examples/04.CustomLogger/dub.json
+++ b/examples/04.CustomLogger/dub.json
@@ -1,12 +1,11 @@
 {
-	"name" : "daemonize-example-01-helloworld",
+	"name" : "daemonize-example-04-customlogger",
 	"copyright": "© 2014 Anton Gushcha",
-	"description" : "Demostrates simple usage of the library",
+	"description" : "Demostrates using a custom logger",
 	"license": "MIT",
 	"authors": ["Anton Gushcha (NCrashed) <ncrashed@gmail.com>"],
 	"dependencies" : {
-		"daemonize": {"version": "~master", "path": "../.."},
-		"dlogg": "~>0.4.1"
+		"daemonize": {"version": "~master", "path": "../.."}
 	},
 	"subConfigurations": {
 		"daemonize": "colorized"

--- a/source/daemonize/d.d
+++ b/source/daemonize/d.d
@@ -8,7 +8,7 @@ module daemonize.d;
 
 public
 {
-    import dlogg.log;
+    import daemonize.log;
     import daemonize.daemon;
     import daemonize.keymap;
 }

--- a/source/daemonize/daemon.d
+++ b/source/daemonize/daemon.d
@@ -124,7 +124,7 @@ template isComposition(alias T)
 *   $(B pSignalMap) is a $(B KeyValueList) template where
 *   keys are $(B Signal) values and values are delegates of type:
 *   ----------
-*   bool delegate(shared ILogger)
+*   bool delegate(shared IDaemonLogger)
 *   ----------
 *   If the delegate returns $(B false), daemon terminates.
 *

--- a/source/daemonize/log.d
+++ b/source/daemonize/log.d
@@ -1,0 +1,106 @@
+module daemonize.log;
+
+version(Have_dlogg)
+{
+    import dlogg.log : LoggingLevel;
+    alias DaemonLogLevel = LoggingLevel;
+}
+else
+{
+    /**
+    *   Logging level options to control log output.
+    */
+    enum DaemonLogLevel
+    {
+        Notice,
+        Warning,
+        Debug,
+        Fatal,
+        Muted
+    }
+}
+
+/**
+*   The interface to use to pass a logger reference into the daemon runner.
+*/
+synchronized interface IDaemonLogger
+{
+    void logDebug(string message) nothrow;
+    void logInfo(lazy string message) nothrow;
+    void logWarning(lazy string message) nothrow;
+    void logError(lazy string message) @trusted nothrow;
+    DaemonLogLevel minLogLevel() @property;
+    void minLogLevel(DaemonLogLevel level) @property;
+    DaemonLogLevel minOutputLevel() @property;
+    void minOutputLevel(DaemonLogLevel level) @property;
+    void finalize() nothrow;
+    void reload();
+}
+
+version(Have_dlogg)
+{
+    /**
+    *   Light wrapper around the Dlogg logger.
+    */
+    synchronized class DloggLogger : IDaemonLogger
+    {
+        import dlogg.strict;
+
+        this(string filePath, StrictLogger.Mode mode = StrictLogger.Mode.Rewrite) @trusted
+        {
+            logger = new shared StrictLogger(filePath, mode);
+        }
+
+        void logDebug(string message) nothrow
+        {
+            logger.logDebug(message);
+        }
+
+        void logInfo(lazy string message) nothrow
+        {
+            logger.logInfo(message);
+        }
+
+        void logWarning(lazy string message) nothrow
+        {
+            logger.logWarning(message);
+        }
+
+        void logError(lazy string message) @trusted nothrow
+        {
+            logger.logError(message);
+        }
+
+        DaemonLogLevel minLogLevel() @property
+        {
+            return logger.minLoggingLevel;
+        }
+
+        void minLogLevel(DaemonLogLevel level) @property
+        {
+            logger.minLoggingLevel = level;
+        }
+
+        DaemonLogLevel minOutputLevel() @property
+        {
+            return logger.minOutputLevel;
+        }
+
+        void minOutputLevel(DaemonLogLevel level) @property
+        {
+            logger.minOutputLevel = level;
+        }
+
+        void finalize() @trusted nothrow
+        {
+            logger.finalize;
+        }
+
+        void reload()
+        {
+            logger.reload;
+        }
+
+        private StrictLogger logger;
+    }
+}

--- a/testing/01/dub.json
+++ b/testing/01/dub.json
@@ -5,6 +5,7 @@
 	"license": "MIT",
 	"authors": ["Anton Gushcha (NCrashed) <ncrashed@gmail.com>"],
 	"dependencies" : {
-		"daemonize": {"version": "~master", "path": "../.."}  
+		"daemonize": {"version": "~master", "path": "../.."},
+		"dlogg": "~>0.4.1"
 	}
 }

--- a/testing/01/source/app.d
+++ b/testing/01/source/app.d
@@ -8,14 +8,13 @@ module test01;
 
 import std.file;
 
-import dlogg.strict;
 import daemonize.d;
 
 alias daemon = Daemon!(
     "Test1",
-    
+
     KeyValueList!(),
-    
+
     (logger, shouldExit) {
         write("output.txt", "Hello World!");
         return 0;
@@ -24,5 +23,5 @@ alias daemon = Daemon!(
 
 int main()
 {
-    return buildDaemon!daemon.run(new shared StrictLogger("logfile.log")); 
+    return buildDaemon!daemon.run(new shared DloggLogger("logfile.log"));
 }

--- a/testing/02/dub.json
+++ b/testing/02/dub.json
@@ -5,7 +5,8 @@
 	"license": "MIT",
 	"authors": ["Anton Gushcha (NCrashed) <ncrashed@gmail.com>"],
 	"dependencies" : {
-		"daemonize": {"version": "~master", "path": "../.."}  
+		"daemonize": {"version": "~master", "path": "../.."},
+		"dlogg": "~>0.4.1"
 	},
 	"configurations": [
 		{
@@ -43,6 +44,6 @@
 			"targetType": "executable",
 			"targetName": "test2-client",
 			"versions": ["Test5"]
-		}		
+		}
 	]
 }

--- a/testing/02/source/app.d
+++ b/testing/02/source/app.d
@@ -8,37 +8,36 @@ module test02;
 
 import std.file;
 
-import dlogg.strict;
 import daemonize.d;
 
 version(Server)
 {
     alias daemon = Daemon!(
         "Test2",
-        
+
         KeyValueList!(
-            Composition!(Signal.Terminate, Signal.Quit, Signal.Shutdown, Signal.Stop), (shared ILogger logger, Signal signal)
+            Composition!(Signal.Terminate, Signal.Quit, Signal.Shutdown, Signal.Stop), (shared IDaemonLogger logger, Signal signal)
             {
                 write("output.txt", "Test string 1");
-                return false; 
+                return false;
             },
             Signal.HangUp, (logger)
             {
                 write("output.txt", "Test string 2");
                 return false;
             }),
-        
+
         (logger, shouldExit) {
             while(!shouldExit()) {}
             return 0;
         }
     );
-    
+
     int main()
     {
-        return buildDaemon!daemon.run(new shared StrictLogger("logfile.log")); 
+        return buildDaemon!daemon.run(new shared DloggLogger("logfile.log"));
     }
-} 
+}
 else
 {
     alias daemon = DaemonClient!(
@@ -46,19 +45,19 @@ else
         Composition!(Signal.Terminate, Signal.Quit, Signal.Shutdown, Signal.Stop),
         Signal.HangUp
     );
-    
+
     int main()
     {
         alias client = buildDaemon!daemon;
-        
+
         Signal sig;
         version(Test1) sig = Signal.Terminate;
         version(Test2) sig = Signal.Quit;
         version(Test3) sig = Signal.Shutdown;
         version(Test4) sig = Signal.Stop;
         version(Test5) sig = Signal.HangUp;
-        
-        client.sendSignal(new shared StrictLogger("logfile.log"), sig);
+
+        client.sendSignal(new shared DloggLogger("logfile.log"), sig);
         return 0;
     }
 }


### PR DESCRIPTION
Provides an interface to pass a logger into the daemon code, and optionally provides a `DloggLogger` class which wraps dlogg. This was designed to minimize disruption for anyone using dlogg - the only necessary change is switching `StrictLogger` to `DloggLogger`. For other logging libraries, the programmer must create a wrapper that implements the `IDaemonLogger` interface.

Notes:
- This also upgrades dlogg to 0.4.1.
- This removes name conflicts with the vibe.d logger.
- The `IDaemonLogger` interface comes from dlogg functions called by daemonize; it is not necessarily the best interface design for a generic logging wrapper.
- A logger is still required; with this PR, it doesn't have to be dlogg.
- My apologies for the noise in linux.d (removing the whitespace throughout the file).