### PR TITLE
remove errant std.c import

### DIFF
--- a/source/daemonize/windows.d
+++ b/source/daemonize/windows.d
@@ -23,7 +23,6 @@ import core.thread;
 import std.string;
 import std.typetuple;
 import std.utf;
-import std.c.stdlib;
 import std.conv : text;
 import std.typecons;
 


### PR DESCRIPTION
This blocks use with newer dmd so a new release with it would be very useful