### PR TITLE
Remove extraneous import.

### DIFF
--- a/source/daemonize/windows.d
+++ b/source/daemonize/windows.d
@@ -23,7 +23,6 @@ import core.thread;
 import std.string;
 import std.typetuple;
 import std.utf;
-import std.c.stdlib;
 import std.conv : text;
 import std.typecons;
 


### PR DESCRIPTION
core.c.stdlib is now core.stdc.stdlib so daemonize won't compile in FE 2.070+. The correct module is already being imported for any version, so this line isn't necessary.